### PR TITLE
Add retainable user conversation context 

### DIFF
--- a/engines/bard_engine.py
+++ b/engines/bard_engine.py
@@ -1,8 +1,7 @@
 import json
 import logging
 import re
-import uuid
-from typing import Any
+from typing import Any, Optional
 
 import boto3
 import requests
@@ -10,10 +9,11 @@ from bardapi import Bard
 
 from .common_utils import encode_message, read_json_from_s3, read_ssm_param, save_to_s3
 from .conversation_history import ConversationHistory
-from .engine_interface import EngineInterface
+from .user_context import UserContext
 
 logging.basicConfig()
 logging.getLogger().setLevel("INFO")
+engine_type = "bard"
 headers = {
     "Host": "bard.google.com",
     "X-Same-Domain": "1",
@@ -29,136 +29,136 @@ cookie_names = [
     "__Secure-1PSIDCC",
     "__Secure-1PAPISID",
 ]
-
-
-class BardEngine(EngineInterface):
-    def __init__(self, chatbot: Bard, cookies: Any) -> None:
-        self.conversation_id = None
-        self.parent_id = str(uuid.uuid4())
-        self.chatbot = chatbot
-        self.cookies = cookies
-        self.history = ConversationHistory()
-        self.esc_pattern = re.compile(f"([{re.escape(r'._-+#|{}!=()<>[]')}])")
-
-    def reset_chat(self) -> None:
-        self.conversation_id = None
-        self.parent_id = str(uuid.uuid4())
-
-    def ask(self, text: str, userConfig: dict) -> str:
-        if "/ping" in text:
-            return "pong"
-
-        try:
-            response = self.chatbot.get_answer(input_text=text)
-        except Exception as e:
-            logging.error("get_answer request failed, check cookies", exc_info=e)
-            return "Sorry, requesting the Bard AI model failed"
-
-        if not response or len(response) < 1 or "content" not in response:
-            logging.error(response)
-            raise Exception("Wrong Bard response, check logs")
-
-        logging.info("Saving cookies")
-        try:
-            if self.chatbot.session and self.chatbot.session.cookies:
-                for i in range(len(self.cookies)):
-                    self.cookies[i]["value"] = self.chatbot.session.cookies.get(
-                        name=self.cookies[i]["name"],
-                        domain=self.cookies[i]["domain"],
-                        path=self.cookies[i]["path"],
-                    )
-                BardEngine.save_cookies(self.cookies)
-
-        except Exception as e:
-            logging.error("Error saving session cookies", exc_info=e)
-
-        self.conversation_id = self.chatbot.conversation_id
-        logging.info(self.conversation_id)
-        item = response["content"]
-        answer = self.as_markdown(item)
-        try:
-            self.history.write(
-                conversation_id=self.conversation_id,
-                request_id=self.parent_id,
-                user_id=userConfig["user_id"],
-                conversation=item,
-            )
-        except Exception as e:
-            logging.error(
-                f"History write error, conversation_id: {self.conversation_id}, error: {e}, item: {item}",
-                exc_info=e,
-            )
-        return answer
-
-    def close(self):
-        pass
-
-    @property
-    def engine_type(self):
-        return "bard"
-
-    @classmethod
-    def read_cookies(cls) -> Any:
-        cookies = read_json_from_s3(bucket_name, "bard-cookies.json")
-        logging.info(f"Read {len(cookies)} cookies from s3")
-        return cookies
-
-    @classmethod
-    def save_cookies(cls, cookies: Any) -> None:
-        save_to_s3(bucket_name, "bard-cookies.json", cookies)
-        logging.info(f"Saved {len(cookies)} cookies to s3")
-
-    @classmethod
-    def create(cls) -> EngineInterface:
-        socks_url = read_ssm_param(param_name="SOCKS5_URL")
-        proxies = {"https": socks_url, "http": socks_url}
-        auth_cookies = BardEngine.read_cookies()
-        psid = [
-            x.get("value") for x in auth_cookies if x.get("name") == "__Secure-1PSID"
-        ][0]
-        session = requests.Session()
-        session.headers = headers
-        for i in range(len(auth_cookies)):
-            if auth_cookies[i]["name"] in cookie_names:
-                session.cookies.set(
-                    name=auth_cookies[i]["name"],
-                    value=auth_cookies[i]["value"],
-                    domain=auth_cookies[i]["domain"],
-                    path=auth_cookies[i]["path"],
-                )
-        logging.info(
-            f"psid {psid}, proxy: {socks_url}, cookies: {len(session.cookies.items())}"
-        )
-        chatbot = Bard(
-            token=psid,
-            proxies=proxies,
-            session=session,
-            timeout=40,
-        )
-        return BardEngine(chatbot, auth_cookies)
-
-    def as_markdown(self, input: str) -> str:
-        input = re.sub(r"(?<!\*)\*(?!\*)", "\\\\*", input)
-        input = re.sub(r"\*{2,}", "*", input)
-        return re.sub(self.esc_pattern, r"\\\1", input)
-
-
 bucket_name = read_ssm_param(param_name="BOT_S3_BUCKET")
 results_queue = read_ssm_param(param_name="RESULTS_SQS_QUEUE_URL")
 sqs = boto3.session.Session().client("sqs")
+user_context = UserContext()
+history = ConversationHistory()
 
-# AWS SQS handler
+
+def ask(chatbot: Bard, request_id: str, text: str, userConfig: dict) -> str:
+    if "/ping" in text:
+        return "pong"
+
+    try:
+        response = chatbot.get_answer(input_text=text)
+    except Exception as e:
+        logging.error("get_answer request failed, check cookies", exc_info=e)
+        return "Sorry, requesting the Bard AI model failed"
+
+    if not response or len(response) < 1 or "content" not in response:
+        logging.error(response)
+        raise Exception("Wrong Bard response, check logs")
+
+    if chatbot.session and chatbot.session.cookies:
+        logging.info("Saving cookies")
+        cookies = []
+        try:
+            for name in cookie_names:
+                cookie_value = chatbot.session.cookies.get(name=name)
+                cookies.append(
+                    {
+                        "name": name,
+                        "value": cookie_value,
+                        "path": "/",
+                        "domain": ".google.com",
+                    }
+                )
+            save_cookies(cookies)
+        except Exception as e:
+            logging.error("Error saving session cookies", exc_info=e)
+
+    item = response["content"]
+    answer = as_markdown(item)
+    return answer
+
+
+def read_cookies() -> Any:
+    cookies = read_json_from_s3(bucket_name, "bard-cookies.json")
+    logging.info(f"Read {len(cookies)} cookies from s3")
+    return cookies
+
+
+def save_cookies(cookies: Any) -> None:
+    save_to_s3(bucket_name, "bard-cookies.json", cookies)
+    logging.info(f"Saved {len(cookies)} cookies to s3")
+
+
+def create(conversation_id: Optional[str]) -> Bard:
+    socks_url = read_ssm_param(param_name="SOCKS5_URL")
+    proxies = {"https": socks_url, "http": socks_url}
+    auth_cookies = read_cookies()
+    psid = [x.get("value") for x in auth_cookies if x.get("name") == "__Secure-1PSID"][
+        0
+    ]
+    session = requests.Session()
+    session.headers = headers
+    for i in range(len(auth_cookies)):
+        if auth_cookies[i]["name"] in cookie_names:
+            session.cookies.set(
+                name=auth_cookies[i]["name"],
+                value=auth_cookies[i]["value"],
+                domain=auth_cookies[i]["domain"],
+                path=auth_cookies[i]["path"],
+            )
+    logging.info(
+        f"psid {psid}, proxy: {socks_url}, cookies: {len(session.cookies.items())}"
+    )
+    return Bard(
+        token=psid,
+        proxies=proxies,
+        conversation_id=conversation_id,
+        session=session,
+        timeout=40,
+    )
+
+
+def as_markdown(input: str) -> str:
+    input = re.sub(r"(?<!\*)\*(?!\*)", "\\\\*", input)
+    input = re.sub(r"\*{2,}", "*", input)
+    esc_pattern = re.compile(f"([{re.escape(r'._-+#|{}!=()<>[]')}])")
+    return re.sub(esc_pattern, r"\\\1", input)
 
 
 def sqs_handler(event, context):
+    """AWS SQS event handler"""
+    request_id = context.aws_request_id
+    logging.info(f"Request ID: {request_id}")
     for record in event["Records"]:
         payload = json.loads(record["body"])
         logging.info(payload)
-        instance = BardEngine.create()
-        response = instance.ask(text=payload["text"], userConfig=payload["config"])
-        payload["response"] = response
-        logging.info(response)
+        user_id = payload["user_id"]
+        user_chat_id = f"{user_id}_{payload['chat_id']}"
+        conversation_id = user_context.read(user_chat_id, engine_type) or None
+        instance = create(conversation_id=conversation_id)
+        response = ask(
+            chatbot=instance,
+            request_id=request_id,
+            text=payload["text"],
+            userConfig=payload["config"],
+        )
+        conversation_id = instance.conversation_id
+        logging.info(
+            f"Saving user_context for {user_chat_id}, engine {engine_type}, conversation_id: {conversation_id}"
+        )
+        user_context.write(
+            user_chat_id=user_chat_id,
+            engine=engine_type,
+            conversation_id=conversation_id,
+        )
+        try:
+            history.write(
+                conversation_id=conversation_id,
+                request_id=request_id,
+                user_id=user_id,
+                conversation=response,
+            )
+        except Exception as e:
+            logging.error(
+                f"History write error, conversation_id: {conversation_id}, request_id: {request_id}",
+                exc_info=e,
+            )
         payload["response"] = encode_message(response)
-        payload["engine"] = instance.engine_type
+        payload["engine"] = engine_type
         logging.info(payload)
         sqs.send_message(QueueUrl=results_queue, MessageBody=json.dumps(payload))

--- a/engines/bing.py
+++ b/engines/bing.py
@@ -1,0 +1,133 @@
+import asyncio
+import json
+import logging
+import re
+
+import boto3
+from EdgeGPT.EdgeGPT import CONVERSATION_STYLE_TYPE, Chatbot
+
+from .common_utils import (
+    encode_message,
+    escape_markdown_v2,
+    read_json_from_s3,
+    read_ssm_param,
+)
+from .user_context import UserContext
+
+logging.basicConfig()
+logging.getLogger().setLevel("INFO")
+
+engine_type = "bing"
+remove_links_pattern = re.compile(r"\[\^\d+\^\]\s?")
+ref_link_pattern = re.compile(r"\[(.*?)\]\:\s?(.*?)\s\"(.*?)\"\n?")
+
+
+def process_command(input: str, context: UserContext) -> None:
+    command = input.removeprefix(prefix="/").lower()
+    if "reset" in command:
+        context.reset_conversation()
+        logging.info(f"Conversation hass been reset for {context.user_id}")
+        return
+    logging.error(f"Unknown command {command}")
+
+
+def ask(
+    text: str,
+    chatbot: Chatbot,
+    style: CONVERSATION_STYLE_TYPE,
+    context: UserContext,
+) -> str:
+    if "/ping" in text:
+        return "pong"
+
+    response = asyncio.run(
+        chatbot.ask(
+            prompt=text,
+            conversation_style=style,
+            webpage_context=context.conversation_id,
+            simplify_response=False,
+        ),
+    )
+    logging.info(response)
+    item = response["item"]
+    context.conversation_id = item["conversationId"]
+    try:
+        return __as_markdown(item)
+    except Exception as e:
+        logging.error(
+            f"chatbot.ask finished with an error. Request:{text}, response item:{item}",
+            exc_info=e,
+        )
+        return __as_plaintext(item)
+
+
+def __as_plaintext(item: dict) -> str:
+    return re.sub(
+        pattern=remove_links_pattern,
+        repl="",
+        string=item["messages"][1]["text"],
+    )
+
+
+def __as_markdown(item: dict) -> str:
+    message = item["messages"][-1]
+    text = message["adaptiveCards"][0]["body"][0]["text"]
+    return __replace_references(text)
+
+
+def __replace_references(text: str) -> str:
+    ref_links = re.findall(pattern=ref_link_pattern, string=text)
+    text = re.sub(pattern=ref_link_pattern, repl="", string=text)
+    text = escape_markdown_v2(text)
+    for link in ref_links:
+        link_label = link[0]
+        link_ref = link[1]
+        inline_link = f" [\[{link_label}\]]({link_ref})"
+        text = re.sub(
+            pattern=rf"\[\^{link_label}\^\]\[\d+\]", repl=inline_link, string=text
+        )
+    return text
+
+
+def create() -> Chatbot:
+    bucket_name = read_ssm_param(param_name="BOT_S3_BUCKET")
+    # socks_url = read_ssm_param(param_name="SOCKS5_URL")
+    # os.environ["all_proxy"] = socks_url
+    chatbot = asyncio.run(
+        Chatbot.create(cookies=read_json_from_s3(bucket_name, "bing-cookies.json"))
+    )
+    return chatbot
+
+
+results_queue = read_ssm_param(param_name="RESULTS_SQS_QUEUE_URL")
+sqs = boto3.session.Session().client("sqs")
+
+
+def sqs_handler(event, context):
+    """AWS SQS event handler"""
+    request_id = context.aws_request_id
+    logging.info(f"Request ID: {request_id}")
+    for record in event["Records"]:
+        payload = json.loads(record["body"])
+        user_id = payload["user_id"]
+        user_context = UserContext(
+            user_id=user_id,
+            chat_id=payload["chat_id"],
+            request_id=request_id,
+            engine_id=engine_type,
+            username=payload["username"],
+        )
+        instance = create()
+        style = payload["config"].get("style", "creative")
+        response = ask(
+            text=payload["text"],
+            chatbot=instance,
+            style=style,
+            context=user_context,
+        )
+        user_context.save_conversation(
+            conversation={"request": payload["text"], "response": response},
+        )
+        payload["response"] = encode_message(response)
+        payload["engine"] = engine_type
+        sqs.send_message(QueueUrl=results_queue, MessageBody=json.dumps(payload))

--- a/engines/user_context.py
+++ b/engines/user_context.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 import boto3
 
@@ -10,30 +10,93 @@ logging.getLogger().setLevel("INFO")
 
 
 class UserContext:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        user_id: str,
+        chat_id: str,
+        engine_id: str,
+        request_id: str,
+        username: Optional[str],
+    ) -> None:
+        self.user_id = f"{user_id}_{chat_id}"
+        self.username = username or "anonymous"
+        self.engine_id = engine_id
+        self.request_id = request_id
         dynamodb = boto3.resource("dynamodb")
-        self.table = dynamodb.Table("user-context")
+        self.context_table = dynamodb.Table("user-context")
+        self.conversations_table = dynamodb.Table("user-conversations")
+        self.conversation_id = self.get_conversation_id()
 
-    def read(self, user_chat_id: str, engine: str) -> Optional[str]:
+    def get_conversation_id(self) -> str:
         try:
-            resp = self.table.get_item(
-                Key={"user_chat": user_chat_id, "engine": engine}
+            resp = self.context_table.get_item(
+                Key={"user_id": self.user_id, "engine": self.engine_id}
             )
             if "Item" in resp and resp["Item"]["conversation_id"]:
-                return json.loads(resp["Item"]["conversation_id"])
-        except Exception:
+                return resp["Item"]["conversation_id"]
+        except Exception as e:
             logging.error(
-                f"Cannot read from 'user-context' table with PK {user_chat_id} and SK {engine}"
+                f"Cannot read from 'user-context' table with PK '{self.user_id}' and SK '{self.engine_id}'",
+                exc_info=e,
             )
         return None
 
-    def write(self, user_chat_id: str, engine: str, conversation_id: str):
-        exp_time = datetime.datetime.utcnow() + datetime.timedelta(days=30)
-        self.table.put_item(
-            Item={
-                "user_chat": user_chat_id,
-                "engine": engine,
-                "conversation_id": conversation_id,
-                "exp": int(exp_time.timestamp()),
-            }
+    def reset_conversation(self) -> None:
+        self.context_table.delete_item(
+            Key={
+                "conversation_id": {
+                    "S": self.conversation_id,
+                }
+            },
+            Table="conversation-id-index",
         )
+        self.conversation_id = None
+
+    def save_conversation(
+        self,
+        conversation: Optional[Any],
+    ):
+        tme = datetime.datetime.utcnow()
+        exp_time = tme + datetime.timedelta(days=60)
+        try:
+            self.context_table.put_item(
+                Item={
+                    "user_id": self.user_id,
+                    "engine": self.engine_id,
+                    "conversation_id": self.conversation_id,
+                    "exp": int(exp_time.timestamp()),
+                }
+            )
+            if self.conversation_id:
+                self.conversations_table.put_item(
+                    Item={
+                        "conversation_id": self.conversation_id,
+                        "request_id": self.request_id,
+                        "user_id": self.user_id,
+                        "engine": self.engine_id,
+                        "timestamp": int(tme.timestamp()),
+                        "conversation": json.dumps(conversation or {}),
+                    }
+                )
+        except Exception as e:
+            logging.error(
+                f"save_conversation filed with error. User: {self.user_id}, engine_id: {self.engine_id}, conversation_id: {self.conversation_id}",
+                exc_info=e,
+            )
+
+    def read_conversation(self) -> Optional[Any]:
+        try:
+            resp = self.conversations_table.get_item(
+                Key={
+                    "conversation_id": self.conversation_id,
+                    "request_id": self.request_id,
+                }
+            )
+            if "Item" in resp:
+                return json.loads(resp["Item"]["conversation"])
+            return None
+        except Exception as e:
+            logging.error(
+                f"read_conversation filed with error. User: {self.user_id}, engine_id: {self.engine_id}, request_id: {self.request_id}, conversation_id: {self.conversation_id}",
+                exc_info=e,
+            )

--- a/engines/user_context.py
+++ b/engines/user_context.py
@@ -1,0 +1,39 @@
+import datetime
+import json
+import logging
+from typing import Optional
+
+import boto3
+
+logging.basicConfig()
+logging.getLogger().setLevel("INFO")
+
+
+class UserContext:
+    def __init__(self) -> None:
+        dynamodb = boto3.resource("dynamodb")
+        self.table = dynamodb.Table("user-context")
+
+    def read(self, user_chat_id: str, engine: str) -> Optional[str]:
+        try:
+            resp = self.table.get_item(
+                Key={"user_chat": user_chat_id, "engine": engine}
+            )
+            if "Item" in resp and resp["Item"]["conversation_id"]:
+                return json.loads(resp["Item"]["conversation_id"])
+        except Exception:
+            logging.error(
+                f"Cannot read from 'user-context' table with PK {user_chat_id} and SK {engine}"
+            )
+        return None
+
+    def write(self, user_chat_id: str, engine: str, conversation_id: str):
+        exp_time = datetime.datetime.utcnow() + datetime.timedelta(days=30)
+        self.table.put_item(
+            Item={
+                "user_chat": user_chat_id,
+                "engine": engine,
+                "conversation_id": conversation_id,
+                "exp": int(exp_time.timestamp()),
+            }
+        )

--- a/stacks/database_stack.py
+++ b/stacks/database_stack.py
@@ -47,3 +47,25 @@ class DatabaseStack(Stack):
             ),
             projection_type=dynamodb.ProjectionType.ALL,
         )
+
+        contextTable = dynamodb.Table(
+            self,
+            "user-context-table",
+            table_name="user-context",
+            partition_key=dynamodb.Attribute(
+                name="user_chat", type=dynamodb.AttributeType.STRING
+            ),
+            sort_key=dynamodb.Attribute(
+                name="engine", type=dynamodb.AttributeType.STRING
+            ),
+            removal_policy=RemovalPolicy.RETAIN,
+            time_to_live_attribute="exp",
+            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
+        )
+        contextTable.add_global_secondary_index(
+            index_name="conversation-id-index",
+            partition_key=dynamodb.Attribute(
+                name="conversation_id", type=dynamodb.AttributeType.STRING
+            ),
+            projection_type=dynamodb.ProjectionType.ALL,
+        )

--- a/stacks/database_stack.py
+++ b/stacks/database_stack.py
@@ -18,6 +18,17 @@ class DatabaseStack(Stack):
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
         )
 
+        dynamodb.Table(
+            self,
+            "configurations-table",
+            table_name="configurations",
+            partition_key=dynamodb.Attribute(
+                name="user_id", type=dynamodb.AttributeType.STRING
+            ),
+            removal_policy=RemovalPolicy.RETAIN,
+            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
+        )
+
         conversationTable = dynamodb.Table(
             self,
             "conversations-table",
@@ -48,12 +59,45 @@ class DatabaseStack(Stack):
             projection_type=dynamodb.ProjectionType.ALL,
         )
 
+        new_conversationTable = dynamodb.Table(
+            self,
+            "user-conversations-table",
+            table_name="user-conversations",
+            partition_key=dynamodb.Attribute(
+                name="conversation_id", type=dynamodb.AttributeType.STRING
+            ),
+            sort_key=dynamodb.Attribute(
+                name="request_id", type=dynamodb.AttributeType.STRING
+            ),
+            removal_policy=RemovalPolicy.RETAIN,
+            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
+        )
+
+        new_conversationTable.add_global_secondary_index(
+            index_name="userid-index",
+            partition_key=dynamodb.Attribute(
+                name="user_id", type=dynamodb.AttributeType.STRING
+            ),
+            sort_key=dynamodb.Attribute(
+                name="engine", type=dynamodb.AttributeType.STRING
+            ),
+            projection_type=dynamodb.ProjectionType.ALL,
+        )
+
+        new_conversationTable.add_local_secondary_index(
+            index_name="timestamp-index",
+            sort_key=dynamodb.Attribute(
+                name="timestamp", type=dynamodb.AttributeType.NUMBER
+            ),
+            projection_type=dynamodb.ProjectionType.ALL,
+        )
+
         contextTable = dynamodb.Table(
             self,
             "user-context-table",
             table_name="user-context",
             partition_key=dynamodb.Attribute(
-                name="user_chat", type=dynamodb.AttributeType.STRING
+                name="user_id", type=dynamodb.AttributeType.STRING
             ),
             sort_key=dynamodb.Attribute(
                 name="engine", type=dynamodb.AttributeType.STRING

--- a/stacks/engines_stack.py
+++ b/stacks/engines_stack.py
@@ -105,10 +105,12 @@ class EnginesStack(Stack):
         self.__create_engine(
             engine_name="Bing",
             sns_filter_policy={
-                "type": aws_sns.SubscriptionFilter.string_filter(allowlist=["text"]),
+                "type": aws_sns.SubscriptionFilter.string_filter(
+                    allowlist=["text", "command"]
+                ),
                 "engines": aws_sns.SubscriptionFilter.string_filter(allowlist=["bing"]),
             },
-            handler=f"{ASSET_PATH}.bing_gpt.sqs_handler",
+            handler=f"{ASSET_PATH}.bing.sqs_handler",
         )
 
         # Bard
@@ -116,7 +118,9 @@ class EnginesStack(Stack):
         self.__create_engine(
             engine_name="Bard",
             sns_filter_policy={
-                "type": aws_sns.SubscriptionFilter.string_filter(allowlist=["text"]),
+                "type": aws_sns.SubscriptionFilter.string_filter(
+                    allowlist=["text", "command"]
+                ),
                 "engines": aws_sns.SubscriptionFilter.string_filter(allowlist=["bard"]),
             },
             handler=f"{ASSET_PATH}.bard_engine.sqs_handler",
@@ -127,7 +131,9 @@ class EnginesStack(Stack):
         self.__create_engine(
             engine_name="ChatGpt",
             sns_filter_policy={
-                "type": aws_sns.SubscriptionFilter.string_filter(allowlist=["text"]),
+                "type": aws_sns.SubscriptionFilter.string_filter(
+                    allowlist=["text", "command"]
+                ),
                 "engines": aws_sns.SubscriptionFilter.string_filter(
                     allowlist=["chatgpt"]
                 ),
@@ -162,7 +168,9 @@ class EnginesStack(Stack):
         self.__create_engine(
             engine_name="LLama",
             sns_filter_policy={
-                "type": aws_sns.SubscriptionFilter.string_filter(allowlist=["text"]),
+                "type": aws_sns.SubscriptionFilter.string_filter(
+                    allowlist=["text", "command"]
+                ),
                 "engines": aws_sns.SubscriptionFilter.string_filter(
                     allowlist=["llama"]
                 ),
@@ -271,7 +279,9 @@ class EnginesStack(Stack):
         self.__create_engine(
             engine_name="Claude",
             sns_filter_policy={
-                "type": aws_sns.SubscriptionFilter.string_filter(allowlist=["text"]),
+                "type": aws_sns.SubscriptionFilter.string_filter(
+                    allowlist=["text", "command"]
+                ),
                 "engines": aws_sns.SubscriptionFilter.string_filter(
                     allowlist=["claude"]
                 ),


### PR DESCRIPTION
The conversation_id has variable format in different APIs so it worth to use hashtable of db table to bind user identifiers to the particular conversation_id.
For simplicity the user ID format is combined from Telegram's `user_id` and `chat_id`, as a PK in table `user_context`. The `engine` is added as SK for separating conversation contexts with different models.