### PR TITLE
Simplify SNS messages fanout 

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -19,14 +19,12 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
-          audience: sts.amazonaws.com
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
           role-skip-session-tagging: true
-          output-credentials: true
           role-session-name: ${{ env.SESSION_NAME }}
         env:
-          SESSION_NAME: "github-${{github.sha}}-dev"
+          SESSION_NAME: "github-${{github.sha}}-${{ env.STAGE }}"
       - name: Setup Node
         uses: actions/setup-node@master
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -22,10 +22,9 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
           role-skip-session-tagging: true
-          output-credentials: true
           role-session-name: ${{ env.SESSION_NAME }}
         env:
-          SESSION_NAME: "github-${{github.sha}}-prod"
+          SESSION_NAME: "github-${{github.sha}}-${{ env.STAGE }}"
       - name: Setup Node
         uses: actions/setup-node@master
         with:

--- a/engines/bing.py
+++ b/engines/bing.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import re
+from typing import Any
 
 import boto3
 from EdgeGPT.EdgeGPT import CONVERSATION_STYLE_TYPE, Chatbot
@@ -104,6 +105,32 @@ def create() -> Chatbot:
 results_queue = read_ssm_param(param_name="RESULTS_SQS_QUEUE_URL")
 sqs = boto3.session.Session().client("sqs")
 
+def __process_payload(payload: Any, request_id: str) -> None:
+    user_id = payload["user_id"]
+    user_context = UserContext(
+        user_id=f"{user_id}_{payload['chat_id']}",
+        request_id=request_id,
+        engine_id=engine_type,
+        username=payload["username"],
+    )
+    if "command" in payload["type"]:
+        process_command(input=payload["text"], context=user_context)
+        return
+
+    instance = create()
+    style = payload["config"].get("style", "creative")
+    response = ask(
+        text=payload["text"],
+        chatbot=instance,
+        style=style,
+        context=user_context,
+    )
+    user_context.save_conversation(
+        conversation={"request": payload["text"], "response": response},
+    )
+    payload["response"] = encode_message(response)
+    payload["engine"] = engine_type
+    sqs.send_message(QueueUrl=results_queue, MessageBody=json.dumps(payload))
 
 def sqs_handler(event, context):
     """AWS SQS event handler"""
@@ -111,28 +138,12 @@ def sqs_handler(event, context):
     logging.info(f"Request ID: {request_id}")
     for record in event["Records"]:
         payload = json.loads(record["body"])
-        user_id = payload["user_id"]
-        user_context = UserContext(
-            user_id=f"{user_id}_{payload['chat_id']}",
-            request_id=request_id,
-            engine_id=engine_type,
-            username=payload["username"],
-        )
-        if "command" in payload["type"]:
-            process_command(input=payload["text"], context=user_context)
-            return
+        __process_payload(payload, request_id)
 
-        instance = create()
-        style = payload["config"].get("style", "creative")
-        response = ask(
-            text=payload["text"],
-            chatbot=instance,
-            style=style,
-            context=user_context,
-        )
-        user_context.save_conversation(
-            conversation={"request": payload["text"], "response": response},
-        )
-        payload["response"] = encode_message(response)
-        payload["engine"] = engine_type
-        sqs.send_message(QueueUrl=results_queue, MessageBody=json.dumps(payload))
+def sns_handler(event, context):
+    """AWS SNS event handler"""
+    request_id = context.aws_request_id
+    logging.info(f"Request ID: {request_id}")
+    for record in event["Records"]:
+        payload = json.loads(record["Sns"]["Message"])
+        __process_payload(payload, request_id)

--- a/engines/claude.py
+++ b/engines/claude.py
@@ -84,10 +84,11 @@ def ask(text: str, context: UserContext, attachment=None):
         headers=headers,
         data=payload,
         impersonate=browser_version,
-        timeout=500,
+        timeout=600,
     )
     if not response.ok:
-        logging.error(f"status:{response.status_code} {response.content}")
+        logging.error(f"POST request returned {response.status_code} {response.reason}")
+        logging.info(response.content.decode("utf-8"))
         logging.info(payload)
 
     decoded_data = response.content.decode("utf-8")

--- a/engines/claude.py
+++ b/engines/claude.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 import uuid
+from typing import Any
 
 import boto3
 from curl_cffi import requests
@@ -176,31 +177,41 @@ results_queue = read_ssm_param(param_name="RESULTS_SQS_QUEUE_URL")
 sqs = boto3.session.Session().client("sqs")
 
 
+def __process_payload(payload: Any, request_id: str) -> None:
+    user_id = payload["user_id"]
+    user_context = UserContext(
+        user_id=f"{user_id}_{payload['chat_id']}",
+        request_id=request_id,
+        engine_id=engine_type,
+        username=payload["username"],
+    )
+    if "command" in payload["type"]:
+        process_command(input=payload["text"], context=user_context)
+        return
+
+    response = ask(payload["text"], context=user_context)
+    user_context.save_conversation(
+        conversation={"request": payload["text"], "response": response},
+    )
+    payload["response"] = encode_message(response)
+    payload["engine"] = engine_type
+    sqs.send_message(QueueUrl=results_queue, MessageBody=json.dumps(payload))
+
 def sqs_handler(event, context):
     """AWS SQS event handler"""
     request_id = context.aws_request_id
     logging.info(f"Request ID: {request_id}")
     for record in event["Records"]:
         payload = json.loads(record["body"])
-        user_id = payload["user_id"]
-        user_context = UserContext(
-            user_id=f"{user_id}_{payload['chat_id']}",
-            request_id=request_id,
-            engine_id=engine_type,
-            username=payload["username"],
-        )
-        if "command" in payload["type"]:
-            process_command(input=payload["text"], context=user_context)
-            return
-
-        response = ask(payload["text"], context=user_context)
-        user_context.save_conversation(
-            conversation={"request": payload["text"], "response": response},
-        )
-        payload["response"] = encode_message(response)
-        payload["engine"] = engine_type
-        sqs.send_message(QueueUrl=results_queue, MessageBody=json.dumps(payload))
-
+        __process_payload(payload, request_id)
+    
+def sns_handler(event, context):
+    """AWS SNS event handler"""
+    request_id = context.aws_request_id
+    logging.info(f"Request ID: {request_id}")
+    for record in event["Records"]:
+        payload = json.loads(record["Sns"]["Message"])
+        __process_payload(payload, request_id)
 
 # if __name__ == "__main__":
 #     put_request("does DALL-E uses stable diffusion?")

--- a/engines/monsterapi_result.py
+++ b/engines/monsterapi_result.py
@@ -26,6 +26,8 @@ headers = {
 
 def callback_handler(event, context) -> None:
     """AWS Lambda event handler"""
+    if(event is None or event.get("body") is None):
+        return
     body = json.loads(event["body"])
     process_id = body["process_id"]
     status = body["status"]

--- a/lambda/chatbot.py
+++ b/lambda/chatbot.py
@@ -7,7 +7,6 @@ import boto3
 import boto3.session
 from botocore.exceptions import ClientError
 from telegram import (
-    BotCommand,
     ReplyKeyboardMarkup,
     ReplyKeyboardRemove,
     Update,


### PR DESCRIPTION
As the SNS-to-SQS fanout is suboptimal due to the SQS polling for lambdas, the engine stack was refactored, SQS queues were removed. 