### PR TITLE
Move request and results to the SNS instead of SQS queue

### DIFF
--- a/engines/bard.py
+++ b/engines/bard.py
@@ -30,8 +30,8 @@ cookie_names = [
     "__Secure-1PAPISID",
 ]
 bucket_name = read_ssm_param(param_name="BOT_S3_BUCKET")
-results_queue = read_ssm_param(param_name="RESULTS_SQS_QUEUE_URL")
-sqs = boto3.session.Session().client("sqs")
+result_topic = read_ssm_param(param_name="RESULT_SNS_TOPIC_ARN")
+sns = boto3.session.Session().client("sns")
 
 
 def process_command(input: str, context: UserContext) -> None:
@@ -148,15 +148,8 @@ def __process_payload(payload: Any, request_id: str) -> None:
     payload["response"] = encode_message(response)
     payload["engine"] = engine_type
     logging.info(payload)
-    sqs.send_message(QueueUrl=results_queue, MessageBody=json.dumps(payload))
+    sns.publish(TopicArn=result_topic, Message=json.dumps(payload))
 
-def sqs_handler(event, context):
-    """AWS SQS event handler"""
-    request_id = context.aws_request_id
-    logging.info(f"Request ID: {request_id}")
-    for record in event["Records"]:
-        payload = json.loads(record["body"])
-        __process_payload(payload, request_id)
 
 def sns_handler(event, context):
     """AWS SNS event handler"""

--- a/engines/bing.py
+++ b/engines/bing.py
@@ -102,8 +102,8 @@ def create() -> Chatbot:
     return chatbot
 
 
-results_queue = read_ssm_param(param_name="RESULTS_SQS_QUEUE_URL")
-sqs = boto3.session.Session().client("sqs")
+result_topic = read_ssm_param(param_name="RESULT_SNS_TOPIC_ARN")
+sns = boto3.session.Session().client("sns")
 
 def __process_payload(payload: Any, request_id: str) -> None:
     user_id = payload["user_id"]
@@ -130,15 +130,7 @@ def __process_payload(payload: Any, request_id: str) -> None:
     )
     payload["response"] = encode_message(response)
     payload["engine"] = engine_type
-    sqs.send_message(QueueUrl=results_queue, MessageBody=json.dumps(payload))
-
-def sqs_handler(event, context):
-    """AWS SQS event handler"""
-    request_id = context.aws_request_id
-    logging.info(f"Request ID: {request_id}")
-    for record in event["Records"]:
-        payload = json.loads(record["body"])
-        __process_payload(payload, request_id)
+    sns.publish(TopicArn=result_topic, Message=json.dumps(payload))
 
 def sns_handler(event, context):
     """AWS SNS event handler"""

--- a/engines/chat_gpt.py
+++ b/engines/chat_gpt.py
@@ -70,8 +70,8 @@ def create(context: UserContext) -> Chatbot:
     return chatbot
 
 
-results_queue = read_ssm_param(param_name="RESULTS_SQS_QUEUE_URL")
-sqs = boto3.session.Session().client("sqs")
+result_topic = read_ssm_param(param_name="RESULT_SNS_TOPIC_ARN")
+sns = boto3.session.Session().client("sns")
 
 
 def __process_payload(payload: Any, request_id: str) -> None:
@@ -90,16 +90,8 @@ def __process_payload(payload: Any, request_id: str) -> None:
     payload["response"] = response
     payload["response"] = encode_message(response)
     payload["engine"] = engine_type
-    # logging.info(payload)
-    sqs.send_message(QueueUrl=results_queue, MessageBody=json.dumps(payload))
+    sns.publish(TopicArn=result_topic, Message=json.dumps(payload))
 
-def sqs_handler(event, context):
-    """AWS SQS event handler"""
-    request_id = context.aws_request_id
-    logging.info(f"Request ID: {request_id}")
-    for record in event["Records"]:
-        payload = json.loads(record["body"])
-        __process_payload(payload, request_id)
 
 def sns_handler(event, context):
     """AWS SNS event handler"""

--- a/engines/dalle_img.py
+++ b/engines/dalle_img.py
@@ -30,8 +30,8 @@ def create() -> ImageGen:
 
 
 imageGen = create()
-results_queue = read_ssm_param(param_name="RESULTS_SQS_QUEUE_URL")
-sqs = boto3.session.Session().client("sqs")
+result_topic = read_ssm_param(param_name="RESULT_SNS_TOPIC_ARN")
+sns = boto3.session.Session().client("sns")
 
 def __process_payload(payload: Any, request_id: str) -> None:
     prompt = payload["text"]
@@ -71,8 +71,7 @@ def __process_payload(payload: Any, request_id: str) -> None:
     message = "\n".join(list)
     payload["response"] = encode_message(message)
     payload["engine"] = engine_type
-    # logging.info(payload)
-    sqs.send_message(QueueUrl=results_queue, MessageBody=json.dumps(payload))
+    sns.publish(TopicArn=result_topic, Message=json.dumps(payload))
 
 
 def sqs_handler(event, context):

--- a/engines/ideogram_img.py
+++ b/engines/ideogram_img.py
@@ -42,12 +42,14 @@ ideogram_result_queue = sqs.get_queue_url(QueueName="Ideogram-Result-Queue")["Qu
 def request_images(prompt: str) -> str:
     payload = {
         "aspect_ratio": "square",
+        "model_version": "V_0_2",
         "channel_id": channel_id,
         "prompt": prompt,
         "raw_or_fun": "raw",
         "speed": "slow",
         "style": "photo",
         "user_id": user_id,
+        "variation_strength": 50
     }
     logging.info(payload)
     response = requests.post(

--- a/engines/ideogram_result.py
+++ b/engines/ideogram_result.py
@@ -20,7 +20,8 @@ browser_version = "chrome110"
 retrieve_metadata_url = "https://ideogram.ai/api/images/retrieve_metadata_request_id/"
 get_images_url = "https://ideogram.ai/api/images/direct/"
 
-results_queue = read_ssm_param(param_name="RESULTS_SQS_QUEUE_URL")
+result_topic = read_ssm_param(param_name="RESULT_SNS_TOPIC_ARN")
+sns = boto3.session.Session().client("sns")
 sqs = boto3.session.Session().client("sqs")
 
 
@@ -84,5 +85,4 @@ def sqs_handler(event, context):
                 f"Saving conversation error. User_id: {user_id}_{payload['chat_id']}, item: {payload}",
                 exc_info=e,
             )
-        # logging.info(payload)
-        sqs.send_message(QueueUrl=results_queue, MessageBody=json.dumps(payload))
+        sns.publish(TopicArn=result_topic, Message=json.dumps(payload))

--- a/engines/ideogram_result.py
+++ b/engines/ideogram_result.py
@@ -11,7 +11,7 @@ from .common_utils import (
 )
 from .user_context import UserContext
 
-logging.basicpayload()
+logging.basicConfig()
 logging.getLogger().setLevel("INFO")
 
 engine_type = "ideogram"
@@ -76,6 +76,7 @@ def sqs_handler(event, context):
             engine_id=engine_type,
             username=payload["username"],
         )
+        user_context.conversation_id = result_id
         try:
             user_context.save_conversation(
                 conversation=payload,

--- a/engines/monsterapi_result.py
+++ b/engines/monsterapi_result.py
@@ -14,9 +14,9 @@ logging.getLogger().setLevel("INFO")
 engine_type = "llama"
 fetch_url = "https://api.monsterapi.ai/v1/status/"
 
-results_queue = read_ssm_param(param_name="RESULTS_SQS_QUEUE_URL")
+result_topic = read_ssm_param(param_name="RESULT_SNS_TOPIC_ARN")
+sns = boto3.session.Session().client("sns")
 token = read_ssm_param(param_name="MONSTERAPI_TOKEN")
-sqs = boto3.session.Session().client("sqs")
 
 headers = {
     "authorization": f"Bearer {token}",
@@ -81,5 +81,5 @@ def callback_handler(event, context) -> None:
                 f"Error on saving conversation_id: {process_id}, request_id:{process_id}, payload: {payload}",
                 exc_info=e,
             )
-    logging.info(payload)
-    sqs.send_message(QueueUrl=results_queue, MessageBody=json.dumps(payload))
+    # logging.info(payload)
+    sns.publish(TopicArn=result_topic, Message=json.dumps(payload))

--- a/lambda/chatbot.py
+++ b/lambda/chatbot.py
@@ -26,6 +26,7 @@ from telegram.ext import (
 from .help_command import help_handler, start_handler
 from .user_config import UserConfig
 from .utils import (
+    escape_markdown_v2,
     generate_transcription,
     read_ssm_param,
     recursive_stringify,
@@ -304,7 +305,7 @@ def __start_redrive_dlq() -> Any:
             except ClientError as e:
                 logging.error(f"Redriving DLQ messages error :{e}")
                 return f"DLQ Redrive failed for {queue_url}"
-    return "Finished DLQ redrive. {} messages moved".format(count)
+    return escape_markdown_v2("Finished DLQ redrive. {} messages moved".format(count))
 
 
 # Translation handlers

--- a/lambda/results.py
+++ b/lambda/results.py
@@ -25,7 +25,8 @@ def response_handler(event, context) -> None:
     """Result SQS processing handler."""
 
     for record in event["Records"]:
-        payload = json.loads(record["body"])
+        payload = json.loads(record["Sns"]["Message"])
+        # payload = json.loads(record["body"])
         chat_id = payload["chat_id"]
         message_id = payload["message_id"]
         message = decode_message(payload["response"])

--- a/stacks/chatbot_stack.py
+++ b/stacks/chatbot_stack.py
@@ -111,7 +111,6 @@ class ChatBotStack(Stack):
         result_handler.add_event_source(
             aws_lambda_event_sources.SnsEventSource(
                 topic=self.result_topic,
-                # dead_letter_queue=result_dlq,
             )
         )
         aws_ssm.StringParameter(
@@ -230,22 +229,6 @@ class ChatBotStack(Stack):
             comparison_operator=aws_cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
         )
 
-        # result_handler_error_alarm = aws_cloudwatch.Alarm(
-        #     self,
-        #     "ResultProcessingHandlerLambdaErrors",
-        #     alarm_name="ResultProcessingHandlerLambdaErrors",
-        #     metric=result_handler.metric_errors(),
-        #     threshold=1,
-        #     evaluation_periods=1,
-        #     datapoints_to_alarm=1,
-        #     treat_missing_data=aws_cloudwatch.TreatMissingData.NOT_BREACHING,
-        #     alarm_description="Alarm when ResultProcessingHandler lambda has errors",
-        #     comparison_operator=aws_cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-        # )
-
         bot_handler_error_alarm.add_alarm_action(
             aws_cloudwatch_actions.SnsAction(alarm_topic)
         )
-        # result_handler_error_alarm.add_alarm_action(
-        #     aws_cloudwatch_actions.SnsAction(alarm_topic)
-        # )

--- a/stacks/chatbot_stack.py
+++ b/stacks/chatbot_stack.py
@@ -53,6 +53,7 @@ class ChatBotStack(Stack):
                 actions=[
                     "sns:Publish",
                     "sns:ReceiveMessage",
+                    "sqs:ReceiveMessage",
                     "sqs:ListQueues",
                     "sqs:SendMessage",
                     "sqs:DeleteMessage",

--- a/stacks/engines_stack.py
+++ b/stacks/engines_stack.py
@@ -49,6 +49,7 @@ class EnginesStack(Stack):
                     "sqs:SendMessage",
                     "sqs:DeleteMessage",
                     "sns:ReceiveMessage",
+                    "sns:Publish",
                 ],
                 resources=["*"],
             )
@@ -74,13 +75,9 @@ class EnginesStack(Stack):
             queue_name="Request-Queues-DLQ",
             removal_policy=RemovalPolicy.DESTROY,
             encryption=aws_sqs.QueueEncryption.SQS_MANAGED,
-            retention_period=Duration.days(3),
+            retention_period=Duration.days(5),
             enforce_ssl=True,
         )
-        # self.dlq = aws_sqs.DeadLetterQueue(
-        #     max_receive_count=1,
-        #     queue=request_dlq,
-        # )
         self.alarm_topic = aws_sns.Topic(
             self,
             "EnginesErrorsAlarms",
@@ -200,7 +197,7 @@ class EnginesStack(Stack):
             queue_name="MonsterApi-Callback-DLQ",
             removal_policy=RemovalPolicy.DESTROY,
             encryption=aws_sqs.QueueEncryption.SQS_MANAGED,
-            retention_period=Duration.days(3),
+            retention_period=Duration.days(5),
             enforce_ssl=True,
         )
         api_callback = DockerImageFunction(
@@ -277,7 +274,7 @@ class EnginesStack(Stack):
                     queue_name="Ideogram-Result-Queue-DLQ",
                     removal_policy=RemovalPolicy.DESTROY,
                     encryption=aws_sqs.QueueEncryption.SQS_MANAGED,
-                    retention_period=Duration.days(3),
+                    retention_period=Duration.days(5),
                     enforce_ssl=True,
                 ),
             ),
@@ -344,6 +341,6 @@ class EnginesStack(Stack):
             aws_lambda_event_sources.SnsEventSource(
                 topic=self.request_topic,
                 filter_policy=sns_filter_policy,
-                dead_letter_queue=self.dlq,
+                # dead_letter_queue=self.dlq,
             )
         )

--- a/stacks/engines_stack.py
+++ b/stacks/engines_stack.py
@@ -266,18 +266,6 @@ class EnginesStack(Stack):
             visibility_timeout=Duration.seconds(5),
             delivery_delay=Duration.seconds(5),
             encryption=aws_sqs.QueueEncryption.SQS_MANAGED,
-            dead_letter_queue=aws_sqs.DeadLetterQueue(
-                max_receive_count=1,
-                queue=aws_sqs.Queue(
-                    self,
-                    "Ideogram-Result-Queue-DLQ",
-                    queue_name="Ideogram-Result-Queue-DLQ",
-                    removal_policy=RemovalPolicy.DESTROY,
-                    encryption=aws_sqs.QueueEncryption.SQS_MANAGED,
-                    retention_period=Duration.days(5),
-                    enforce_ssl=True,
-                ),
-            ),
             enforce_ssl=True,
         )
         resultHandler = DockerImageFunction(
@@ -292,6 +280,8 @@ class EnginesStack(Stack):
             ),
             log_retention=aws_logs.RetentionDays.TWO_WEEKS,
             role=self.lambda_role,
+            dead_letter_queue_enabled=True,
+            dead_letter_queue=self.dlq,
         )
         resultHandler.add_event_source(
             aws_lambda_event_sources.SqsEventSource(resultQueue)
@@ -341,6 +331,5 @@ class EnginesStack(Stack):
             aws_lambda_event_sources.SnsEventSource(
                 topic=self.request_topic,
                 filter_policy=sns_filter_policy,
-                # dead_letter_queue=self.dlq,
             )
         )


### PR DESCRIPTION
Notes:

- Using SNS pub/sub instead of SQS for requests and results 
- Added DLQ redrive to SNS in admin commands
- Ideogram model version bump to v0.2 